### PR TITLE
Adding DNS Made Easy, Constellix, and Simple DNS Plus to supported services list

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,6 +288,9 @@
 							<li>Knot DNS &#x2265;2.2.0</li>
 							<li>Google Cloud DNS</li>
 							<li>DNSimple</li>
+							<li>DNS Made Easy</li>
+							<li>Constellix DNS</li>
+							<li>Simple DNS Plus &#x2265; 6.0</li>
 						</ul>
 						<p>
 							Please


### PR DESCRIPTION
Hi Andrew,
Thank you for the awesome work. 

There are some issues in queue that mentions a few additional services that support CAA RR type. 
 - #31 - DNS Made Easy.
 - #30 - Constellix
 - #28 - Simple DNS Plus. 

PR with the changes made to the index.html file. 

Thank you!