### PR TITLE
freedns.afraid.org supports CAA records

### DIFF
--- a/index.html
+++ b/index.html
@@ -314,6 +314,7 @@
 							<li>DNSimple</li>
 							<li>DNS Made Easy</li>
 							<li>Constellix DNS</li>
+							<li>Afraid.org Free DNS</li>
 						</ul>
 
 						<p>


### PR DESCRIPTION
https://freedns.afraid.org/news/

Could we add them too, please?

Thanks. 