### PR TITLE
add cloudflare to DNS services

### DIFF
--- a/index.html
+++ b/index.html
@@ -314,6 +314,7 @@
 							<li>DNSimple</li>
 							<li>DNS Made Easy</li>
 							<li>Constellix DNS</li>
+							<li>Cloudflare (in beta)</li>
 						</ul>
 
 						<p>


### PR DESCRIPTION
Cloudflare now has this in beta (you must ask support to enable it for you first).