### PR TITLE
Add Nucleus NV as a provider of CAA records on their nameservers

### DIFF
--- a/support.xml
+++ b/support.xml
@@ -136,6 +136,9 @@
 					<provider>
 						<name>Zilore</name>
 					</provider>
+					<provider>
+						<name>Nucleus NV</name>
+					</provider>
 					<provider support="broken">
 						<name>NameBright</name>
 						<comments><xhtml:a href="https://community.letsencrypt.org/t/caa-servfails-from-namebrightdns-com/38748">Returns invalid response to CAA queries</xhtml:a></comments>


### PR DESCRIPTION
Hi all,

First of all: great work on the CAA tool!

I'd like to add [Nucleus NV](https://www.nucleus.be/en/) to the list of providers that support CAA records. Here's a demo domain, managed through the Nucleus controlpanel.

```
$ dig mojah.be NS | sort
mojah.be.		86392	IN	NS	ns1.nucleus.be.
mojah.be.		86392	IN	NS	ns2.nucleus.be.
mojah.be.		86392	IN	NS	ns3.nucleus.be.
mojah.be.		86392	IN	NS	ns4.nucleus.be.
```

And the CAA record;
```
$ dig mojah.be CAA
mojah.be.		3600	IN	CAA	0 issue "letsencrypt.org"
mojah.be.		3600	IN	CAA	0 iodef "mailto:m@ttias.be"
```

Take care,

Mattias