### PR TITLE
Add Digital Ocean to DNS support page

### DIFF
--- a/support.xml
+++ b/support.xml
@@ -179,6 +179,9 @@
 					<provider>
 						<name>Vultr</name>
 					</provider>
+					<provider>
+						<name>Digital Ocean</name>
+					</provider>
 				</support>
 			</div>
 		</div>


### PR DESCRIPTION
Digital Ocean also has started to offer CAA record in their DNS offering: https://www.digitalocean.com/community/tutorials/how-to-create-and-manage-caa-records-using-digitalocean-dns