### PR TITLE
Linode has added support for CAA records

### DIFF
--- a/support.xml
+++ b/support.xml
@@ -191,6 +191,9 @@
 					<provider>
 						<name>easyDNS</name>
 					</provider>
+					<provider>
+						<name>Linode</name>
+					</provider>
 				</support>
 			</div>
 		</div>


### PR DESCRIPTION
Users can now add CAA records via manager.linode.com and the current API  🎉 