### PR TITLE
Add hosting.de to supported providers

### DIFF
--- a/support.xml
+++ b/support.xml
@@ -170,6 +170,9 @@
 					<provider>
 						<name>Hetzner</name>
 					</provider>
+					<provider>
+						<name>hosting.de</name>
+					</provider>
 					<provider support="no">
 						<name>STRATO</name>
 					</provider>


### PR DESCRIPTION
Documentation (API): https://www.hosting.de/api/#the-record-object (type) also available from the interface: https://secure.hosting.de