### PR TITLE
Add Metaname.net

### DIFF
--- a/support.xml
+++ b/support.xml
@@ -276,6 +276,9 @@
 					<provider>
 						<name>UKFast</name>
 					</provider>
+					<provider>
+						<name>Metaname</name>
+					</provider>
 				</support>
 			</div>
 		</div>


### PR DESCRIPTION
[Metaname](https://metaname.net) just added support for the CAA record.