### PR TITLE
Add Glauca to list of providers supporting CAA

### DIFF
--- a/support.xml
+++ b/support.xml
@@ -276,6 +276,9 @@
 					<provider>
 						<name>UKFast</name>
 					</provider>
+					<provider>
+						<name>Glauca HexDNS</name>
+					</provider>
 				</support>
 			</div>
 		</div>


### PR DESCRIPTION
HexDNS is the DNS service provided by [Glauca Digital](https://glauca.digital/).