### PR TITLE
fix: always print issuewild list entry

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -189,13 +189,11 @@ function init_caa_generator (sslmate_domain, form, ca_table, output_zonefile, ou
 					records.push(new Record(0, "issue", this.issue[i]));
 				}
 			}
-			if (!array_equals(this.issue, this.issuewild)) {
-				if (this.issuewild.length == 0) {
-					records.push(new Record(0, "issuewild", ";"));
-				} else {
-					for (i = 0; i < this.issuewild.length; ++i) {
-						records.push(new Record(0, "issuewild", this.issuewild[i]));
-					}
+			if (this.issuewild.length == 0) {
+				records.push(new Record(0, "issuewild", ";"));
+			} else {
+				for (i = 0; i < this.issuewild.length; ++i) {
+					records.push(new Record(0, "issuewild", this.issuewild[i]));
 				}
 			}
 			if (this.iodef != "") {


### PR DESCRIPTION
To me this seems to be the proper solution.  Locally the change does what I expect.

<img width="809" alt="Screenshot 2025-04-21 at 14 00 53" src="https://github.com/user-attachments/assets/89ae7ea1-ff31-424f-b526-77af3740bdce" />

---

<img width="947" alt="Screenshot 2025-04-21 at 14 01 02" src="https://github.com/user-attachments/assets/9f52a19b-4ae7-4259-a249-4e29d6b5e5ce" />

Fixes #142.